### PR TITLE
Add probes to deployments

### DIFF
--- a/api-node/base/deployment.yaml
+++ b/api-node/base/deployment.yaml
@@ -41,6 +41,14 @@ spec:
             limits:
               memory: 512Mi
               cpu: 200m
+          startupProbe:
+            httpGet:
+              path: /api
+              port: 3000
+          livenessProbe:
+            httpGet:
+              path: /api
+              port: 3000
           readinessProbe:
             httpGet:
               path: /api

--- a/web-nuxt/base/deployment.yaml
+++ b/web-nuxt/base/deployment.yaml
@@ -40,3 +40,15 @@ spec:
             limits:
               memory: 512Mi
               cpu: 200m
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 3
+            periodSeconds: 15
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 5
+            periodSeconds: 15

--- a/web-nuxt/base/deployment.yaml
+++ b/web-nuxt/base/deployment.yaml
@@ -40,15 +40,15 @@ spec:
             limits:
               memory: 512Mi
               cpu: 200m
+          startupProbe:
+            httpGet:
+              path: /
+              port: 8080
           livenessProbe:
             httpGet:
-              path: /api/health
-              port: 3000
-            initialDelaySeconds: 3
-            periodSeconds: 15
+              path: /
+              port: 8080
           readinessProbe:
             httpGet:
-              path: /api/health
-              port: 3000
-            initialDelaySeconds: 5
-            periodSeconds: 15
+              path: /
+              port: 8080

--- a/web-vue/base/deployment.yaml
+++ b/web-vue/base/deployment.yaml
@@ -40,7 +40,15 @@ spec:
             limits:
               memory: 64Mi
               cpu: 200m
+          startupProbe:
+            httpGet:
+              path: /
+              port: 80
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 80
           readinessProbe:
             httpGet:
-              path: /index.html
+              path: /
               port: 80


### PR DESCRIPTION
Added liveness & readiness probes to the Nuxt deployment.

All Nuxt projects should add this in their repo. This is necessary since autorestart=false in the nuxt deamon.

```ts
// server/api/health.ts
export default defineEventHandler(() => 'OK')
```