### PR TITLE
Align labels to make more uniform

### DIFF
--- a/api-node/base/deployment.yaml
+++ b/api-node/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: api
   labels:
     app: api
-    tier: backend
 spec:
   replicas: 1
   selector:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: api
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/api-node/base/kustomization.yaml
+++ b/api-node/base/kustomization.yaml
@@ -2,3 +2,9 @@
 resources:
   - deployment.yaml
   - service.yaml
+labels:
+  - pairs:
+      app: api
+      stack: node
+      tier: backend
+    includeTemplates: true

--- a/api-node/base/service.yaml
+++ b/api-node/base/service.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api-service
-  labels:
-    app: api
 spec:
   ports:
     - name: http

--- a/api-node/components/scheduler/cronjob.yaml
+++ b/api-node/components/scheduler/cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
   name: api-scheduler
   labels:
     app: api
+    stack: node
     tier: backend
 spec:
   schedule: '*/30 * * * *'

--- a/api-node/components/websockets/deployment.yaml
+++ b/api-node/components/websockets/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: api-websockets
   labels:
     app: api
+    stack: node
     tier: backend
 spec:
   replicas: 1
@@ -20,6 +21,8 @@ spec:
     metadata:
       labels:
         app: api-websockets
+        stack: node
+        tier: backend
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/api-node/components/websockets/service.yaml
+++ b/api-node/components/websockets/service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: api-websockets-service
   labels:
     app: api
+    stack: node
+    tier: backend
 spec:
   ports:
     - name: http

--- a/api-node/components/worker/deployment.yaml
+++ b/api-node/components/worker/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: api-worker
   labels:
     app: api
+    stack: node
     tier: backend
 spec:
   replicas: 1
@@ -20,6 +21,8 @@ spec:
     metadata:
       labels:
         app: api-worker
+        stack: node
+        tier: backend
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/api-php/base/deployment.yaml
+++ b/api-php/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: api
   labels:
     app: api
-    tier: backend
 spec:
   replicas: 1
   selector:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: api
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/api-php/base/kustomization.yaml
+++ b/api-php/base/kustomization.yaml
@@ -2,3 +2,9 @@
 resources:
   - deployment.yaml
   - service.yaml
+labels:
+  - pairs:
+      app: api
+      stack: php
+      tier: backend
+    includeTemplates: true

--- a/api-php/base/service.yaml
+++ b/api-php/base/service.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: api-service
-  labels:
-    app: api
 spec:
   ports:
     - name: http

--- a/api-php/components/queue/deployment.yaml
+++ b/api-php/components/queue/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: api-queue
   labels:
     app: api
+    stack: php
     tier: backend
 spec:
   replicas: 1
@@ -20,6 +21,8 @@ spec:
     metadata:
       labels:
         app: api-queue
+        stack: php
+        tier: backend
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/api-php/components/scheduler/deployment.yaml
+++ b/api-php/components/scheduler/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: api-scheduler
   labels:
     app: api
+    stack: php
     tier: backend
 spec:
   replicas: 1
@@ -20,6 +21,8 @@ spec:
     metadata:
       labels:
         app: api-scheduler
+        stack: php
+        tier: backend
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/api-php/components/websockets/deployment.yaml
+++ b/api-php/components/websockets/deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: api-websockets
   labels:
     app: api
+    stack: php
     tier: backend
 spec:
   replicas: 1
@@ -20,6 +21,8 @@ spec:
     metadata:
       labels:
         app: api-websockets
+        stack: php
+        tier: backend
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/api-php/components/websockets/service.yaml
+++ b/api-php/components/websockets/service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: api-websockets-service
   labels:
     app: api
+    stack: php
+    tier: backend
 spec:
   ports:
     - name: http

--- a/benthos/base/deployment.yaml
+++ b/benthos/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: benthos
   labels:
     app: benthos
-    tier: benthos
 spec:
   replicas: 1
   selector:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: benthos
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/benthos/base/kustomization.yaml
+++ b/benthos/base/kustomization.yaml
@@ -1,3 +1,9 @@
 ---
 resources:
   - deployment.yaml
+labels:
+  - pairs:
+      app: benthos
+      service: benthos
+      tier: service
+    includeTemplates: true

--- a/cms-directus/base/deployment.yaml
+++ b/cms-directus/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: cms
   labels:
     app: cms
-    tier: backend
 spec:
   replicas: 1
   selector:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: cms
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/cms-directus/base/kustomization.yaml
+++ b/cms-directus/base/kustomization.yaml
@@ -2,3 +2,9 @@
 resources:
   - deployment.yaml
   - service.yaml
+labels:
+  - pairs:
+      app: cms
+      stack: directus
+      tier: backend
+    includeTemplates: true

--- a/cms-directus/base/service.yaml
+++ b/cms-directus/base/service.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cms-service
-  labels:
-    app: cms
 spec:
   ports:
     - name: http

--- a/cms-payload/base/deployment.yaml
+++ b/cms-payload/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: cms
   labels:
     app: cms
-    tier: backend
 spec:
   replicas: 1
   selector:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: cms
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/cms-payload/base/kustomization.yaml
+++ b/cms-payload/base/kustomization.yaml
@@ -2,3 +2,9 @@
 resources:
   - deployment.yaml
   - service.yaml
+labels:
+  - pairs:
+      app: cms
+      stack: payload
+      tier: backend
+    includeTemplates: true

--- a/cms-payload/base/service.yaml
+++ b/cms-payload/base/service.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cms-service
-  labels:
-    app: cms
 spec:
   ports:
     - name: http

--- a/matomo/base/deployment.yaml
+++ b/matomo/base/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: matomo
-  namespace: matomo
   labels:
     app: matomo
 spec:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: matomo
     spec:
       initContainers:
         - name: init

--- a/matomo/base/kustomization.yaml
+++ b/matomo/base/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+namespace: matomo
 resources:
   - deployment.yaml
   - namespace.yaml
@@ -8,3 +9,9 @@ images:
   - name: default-matomo
     newName: ghcr.io/wisemen-digital/matomo
     newTag: latest
+labels:
+  - pairs:
+      app: matomo
+      service: matomo
+      tier: service
+    includeTemplates: true

--- a/matomo/base/namespace.yaml
+++ b/matomo/base/namespace.yaml
@@ -3,5 +3,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: matomo
-  labels:
-    app: matomo

--- a/matomo/base/service.yaml
+++ b/matomo/base/service.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: matomo-service
-  namespace: matomo
-  labels:
-    app: matomo
 spec:
   ports:
     - name: http

--- a/matomo/base/volume.yaml
+++ b/matomo/base/volume.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: matomo-data-pvc
-  namespace: matomo
-  labels:
-    app: matomo
 spec:
   accessModes:
     - ReadWriteOnce

--- a/matomo/components/link-to-shared/service.yaml
+++ b/matomo/components/link-to-shared/service.yaml
@@ -5,6 +5,8 @@ metadata:
   name: shared-matomo-service
   labels:
     app: matomo
+    service: matomo
+    tier: service
 spec:
   type: ExternalName
   externalName: shared-matomo-service.shared-matomo

--- a/pgbouncer/base/configmap.yaml
+++ b/pgbouncer/base/configmap.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: configmap-pgbouncer
-  labels:
-    app: pgbouncer
-    service: pgbouncer
 data:
   POOL_MODE: transaction
   DEFAULT_POOL_SIZE: 30

--- a/pgbouncer/base/deployment.yaml
+++ b/pgbouncer/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: pgbouncer
   labels:
     app: pgbouncer
-    service: pgbouncer
 spec:
   replicas: 1
   selector:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: pgbouncer
     spec:
       terminationGracePeriodSeconds: 120
       containers:

--- a/pgbouncer/base/kustomization.yaml
+++ b/pgbouncer/base/kustomization.yaml
@@ -7,3 +7,9 @@ images:
   - name: default-pgbouncer
     newName: edoburu/pgbouncer
     newTag: latest
+labels:
+  - pairs:
+      app: pgbouncer
+      service: pgbouncer
+      tier: service
+    includeTemplates: true

--- a/pgbouncer/base/service.yaml
+++ b/pgbouncer/base/service.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: pgbouncer
-  labels:
-    app: pgbouncer
-    service: pgbouncer
 spec:
   clusterIP: None
   ports:

--- a/redis/base/configmap.yaml
+++ b/redis/base/configmap.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: redis-config-file
-  labels:
-    app: redis
-    service: redis
 data:
   redis.conf: |
     maxmemory 225mb

--- a/redis/base/kustomization.yaml
+++ b/redis/base/kustomization.yaml
@@ -8,3 +8,9 @@ images:
   - name: default-redis
     newName: redis
     newTag: 7-alpine
+labels:
+  - pairs:
+      app: redis
+      service: redis
+      tier: service
+    includeTemplates: true

--- a/redis/base/service.yaml
+++ b/redis/base/service.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  labels:
-    app: redis
-    service: redis
 spec:
   ports:
     - name: redis

--- a/redis/base/statefulset.yaml
+++ b/redis/base/statefulset.yaml
@@ -5,20 +5,15 @@ metadata:
   name: redis
   labels:
     app: redis
-    service: redis
 spec:
   serviceName: redis
   podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
-      service: redis
       app: redis
+      service: redis
   template:
-    metadata:
-      labels:
-        app: redis
-        service: redis
     spec:
       terminationGracePeriodSeconds: 300
       containers:

--- a/redis/base/volume.yaml
+++ b/redis/base/volume.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: redis-pvc
-  labels:
-    app: redis
-    service: redis
 spec:
   accessModes:
     - ReadWriteOnce

--- a/signoz-otel-collector/base/kustomization.yaml
+++ b/signoz-otel-collector/base/kustomization.yaml
@@ -1,5 +1,11 @@
 ---
 namespace: signoz-otel-collector
+labels:
+  - pairs:
+      app: signoz-otel-collector
+      service: signoz-otel-collector
+      tier: service
+    includeTemplates: true
 resources:
   - configmap.yaml
   - namespace.yaml

--- a/typesense/base/configmap.yaml
+++ b/typesense/base/configmap.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: configmap-typesense
-  labels:
-    app: typesense
-    service: typesense
 data:
   TYPESENSE_DATA_DIR: /usr/share/typesense/data
   TYPESENSE_API_KEY: ldflDFA212sDFSKLJLJ234567jhfhgdg

--- a/typesense/base/kustomization.yaml
+++ b/typesense/base/kustomization.yaml
@@ -8,3 +8,9 @@ images:
   - name: default-typesense
     newName: typesense/typesense
     newTag: '26.0'
+labels:
+  - pairs:
+      app: typesense
+      service: typesense
+      tier: service
+    includeTemplates: true

--- a/typesense/base/service.yaml
+++ b/typesense/base/service.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: typesense
-  labels:
-    app: typesense
-    service: typesense
 spec:
   clusterIP: None
   ports:

--- a/typesense/base/statefulset.yaml
+++ b/typesense/base/statefulset.yaml
@@ -5,20 +5,15 @@ metadata:
   name: typesense
   labels:
     app: typesense
-    service: typesense
 spec:
   serviceName: typesense
   podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
-      service: typesense
       app: typesense
+      service: typesense
   template:
-    metadata:
-      labels:
-        app: typesense
-        service: typesense
     spec:
       securityContext:
         fsGroup: 2000

--- a/typesense/base/volume.yaml
+++ b/typesense/base/volume.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: typesense-pvc
-  labels:
-    app: typesense
-    service: typesense
 spec:
   accessModes:
     - ReadWriteOnce

--- a/web-nuxt/base/deployment.yaml
+++ b/web-nuxt/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: web
   labels:
     app: web
-    tier: frontend
 spec:
   replicas: 1
   selector:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: web
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/web-nuxt/base/kustomization.yaml
+++ b/web-nuxt/base/kustomization.yaml
@@ -2,3 +2,9 @@
 resources:
   - deployment.yaml
   - service.yaml
+labels:
+  - pairs:
+      app: web
+      stack: nuxt
+      tier: frontend
+    includeTemplates: true

--- a/web-nuxt/base/service.yaml
+++ b/web-nuxt/base/service.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: web-service
-  labels:
-    app: web
 spec:
   ports:
     - name: http

--- a/web-vue/base/deployment.yaml
+++ b/web-vue/base/deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   name: web
   labels:
     app: web
-    tier: frontend
 spec:
   replicas: 1
   selector:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: web
     spec:
       imagePullSecrets:
         - name: docker-secret

--- a/web-vue/base/kustomization.yaml
+++ b/web-vue/base/kustomization.yaml
@@ -2,3 +2,9 @@
 resources:
   - deployment.yaml
   - service.yaml
+labels:
+  - pairs:
+      app: web
+      stack: vue
+      tier: frontend
+    includeTemplates: true

--- a/web-vue/base/service.yaml
+++ b/web-vue/base/service.yaml
@@ -3,8 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: web-service
-  labels:
-    app: web
 spec:
   ports:
     - name: http

--- a/zitadel/base/deployment.yaml
+++ b/zitadel/base/deployment.yaml
@@ -3,7 +3,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: zitadel
-  namespace: zitadel
   labels:
     app: zitadel
 spec:
@@ -17,9 +16,6 @@ spec:
       maxUnavailable: 50%
     type: RollingUpdate
   template:
-    metadata:
-      labels:
-        app: zitadel
     spec:
       initContainers:
         - name: init

--- a/zitadel/base/kustomization.yaml
+++ b/zitadel/base/kustomization.yaml
@@ -1,4 +1,5 @@
 ---
+namespace: zitadel
 resources:
   - configmap.yaml
   - deployment.yaml
@@ -8,3 +9,9 @@ images:
   - name: default-zitadel
     newName: ghcr.io/zitadel/zitadel
     newTag: latest
+labels:
+  - pairs:
+      app: zitadel
+      service: zitadel
+      tier: service
+    includeTemplates: true

--- a/zitadel/base/namespace.yaml
+++ b/zitadel/base/namespace.yaml
@@ -3,5 +3,3 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: zitadel
-  labels:
-    app: zitadel

--- a/zitadel/base/service.yaml
+++ b/zitadel/base/service.yaml
@@ -3,9 +3,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: zitadel-service
-  namespace: zitadel
-  labels:
-    app: zitadel
 spec:
   ports:
     - name: http


### PR DESCRIPTION
Ensure every resource has similar labels:
- Tier will be either `frontend`, `backend` or `service`
- App will usually be the "type" of app, such as `api`, `web`, `cms` or just the name of the service.
- For non-service resources, the `stack` label will point to the "stack" we're working with (node, php, …)
- For service resources, the `service` will be the type of service (same as `app` normally)

This only applies to the resources' `.metadata.labels` and (where applicable) `.spec.template.metadata.labels`, which we're allowed to change. It does **NOT** touch the `.spec.selector` of resources, we can't change those, we'd need to delete & recreate resources for that 🤷 So, if we want to change those, we'll need to create dedicated PRs & have manual deployments.