### PR TITLE
Add "common base" for all projects

### DIFF
--- a/common/base/ingress.yaml
+++ b/common/base/ingress.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    nginx.ingress.kubernetes.io/proxy-body-size: '0'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '600'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '600'
+    nginx.ingress.kubernetes.io/from-to-www-redirect: 'true'
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - host
+      secretName: name
+  rules: []

--- a/common/base/kustomization.yaml
+++ b/common/base/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+resources:
+  - ingress.yaml
+  - namespace.yaml
+configMapGenerator:
+  - name: configmap-common
+    envs: []

--- a/common/base/namespace.yaml
+++ b/common/base/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: placeholder


### PR DESCRIPTION
Provides default namespace, ingress & common configmap. Will eventually contain common stuff like configs, priority classes, etc…

Every project should at the root (base) import this as a resource:
```yaml
resources:
 - https://github.com/wisemen-digital/sysops-k8s-modules//common/base/
```